### PR TITLE
feat: add support for double and decimal column definitions in schema…

### DIFF
--- a/src/Contracts/SchemaBuilderInterface.php
+++ b/src/Contracts/SchemaBuilderInterface.php
@@ -193,4 +193,20 @@ interface SchemaBuilderInterface
      * @return array
      */
     public function build(): array;
+
+    /**
+     * @param string $name
+     * @param int $precision
+     * @param int $scale
+     * @return ColumnDefinitionBuilder
+     */
+    public function double(string $name, int $precision = 10, int $scale = 2): ColumnDefinitionBuilder;
+
+    /**
+     * @param string $name
+     * @param int $precision
+     * @param int $scale
+     * @return ColumnDefinitionBuilder
+     */
+    public function decimal(string $name, int $precision = 10, int $scale = 2): ColumnDefinitionBuilder;
 }

--- a/src/Db/Builder/SchemaBuilder.php
+++ b/src/Db/Builder/SchemaBuilder.php
@@ -283,6 +283,22 @@ class SchemaBuilder implements SchemaBuilderInterface
     }
 
     /**
+     * @inheritDoc
+     */
+    public function double(string $name, int $precision = 10, int $scale = 2): ColumnDefinitionBuilder
+    {
+        return $this->column($name, 'DOUBLE(' . $precision . ', ' . $scale . ')');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function decimal(string $name, int $precision = 10, int $scale = 2): ColumnDefinitionBuilder
+    {
+        return $this->column($name, 'DECIMAL(' . $precision . ', ' . $scale . ')');
+    }
+
+    /**
      * @param string $column
      * @return string
      */


### PR DESCRIPTION
… builder interface [skip-ci]

# Task

# Description

<!--- START AUTOGENERATED NOTES --->
# Contents ([#32](https://github.com/asteriosframework/core/pull/32))

### Other
- add support for double and decimal column definitions in schema builder interface [skip-ci]

<!--- END AUTOGENERATED NOTES --->


# Codecov AI

@codecov-ai-reviewer test
@codecov-ai-reviewer review

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes