### PR TITLE
fix: replace static `VERSION` constant with dynamic version retrieval…

### DIFF
--- a/src/Asterios.php
+++ b/src/Asterios.php
@@ -3,14 +3,10 @@
 namespace Asterios\Core;
 
 use Asterios\Core\Exception\AsteriosException;
+use Composer\InstalledVersions;
 
 class Asterios
 {
-    /**
-     * @var  string  The version of Asterios PHP Framework
-     */
-    public const string VERSION = '1.9.0';
-
     /**
      * @var  string  The version of Asterios PHP Framework
      */
@@ -53,6 +49,17 @@ class Asterios
      * @var bool It will be true if Asterios has been initialized
      */
     private static bool $initialized = false;
+
+
+    public static function version(): ?string
+    {
+        return InstalledVersions::getPrettyVersion('asterios/core');
+    }
+
+    public static function twigVersion(): ?string
+    {
+        return InstalledVersions::getPrettyVersion('twig/twig');
+    }
 
     /**
      * @param string $environment

--- a/src/Cli/Commands/AboutCommand.php
+++ b/src/Cli/Commands/AboutCommand.php
@@ -23,10 +23,11 @@ class AboutCommand extends BaseCommand
         $this->printDataTable([
             'System' => [
                 'PHP Version' => PHP_VERSION,
-                'Framework Version' => Asterios::VERSION,
+                'Framework Version' => Asterios::version(),
                 'Environment' => Asterios::getEnvironment(),
                 'Encoding' => Asterios::getEncoding(),
                 'Timezone' => Asterios::getTimezone(),
+                'Template engine: ' => 'Twig ' . Asterios::twigVersion()
             ],
         ]);
     }

--- a/src/Traits/Cli/Commands/CommandsBuilderTrait.php
+++ b/src/Traits/Cli/Commands/CommandsBuilderTrait.php
@@ -279,8 +279,6 @@ trait CommandsBuilderTrait
             str_contains($label, 'version') => '🛠',
             str_contains($label, 'debug') => $value ? '🐞' : '✅',
             str_contains($label, 'cache') => '🗃',
-            str_contains($label, 'env') => '🌍',
-            str_contains($label, 'php') => '🐘',
             str_contains($label, 'db') => '🛢',
             default => '🛠',
         };

--- a/tests/Cli/Commands/AboutCommandTest.php
+++ b/tests/Cli/Commands/AboutCommandTest.php
@@ -19,7 +19,7 @@ class AboutCommandTest extends MockeryTestCase
         $expectedData = [
             'System' => [
                 'PHP Version' => PHP_VERSION,
-                'Framework Version' => Asterios::VERSION,
+                'Framework Version' => Asterios::version(),
                 'Environment' => Asterios::getEnvironment(),
                 'Encoding' => Asterios::getEncoding(),
                 'Timezone' => Asterios::getTimezone(),


### PR DESCRIPTION
… and add Twig version display

# Task

# Description

<!--- START AUTOGENERATED NOTES --->
# Contents ([#105](https://github.com/asteriosframework/core/pull/105))

### Other
- replace static `VERSION` constant with dynamic version retrieval and add Twig version display

<!--- END AUTOGENERATED NOTES --->


# Codecov AI

@codecov-ai-reviewer test
@codecov-ai-reviewer review

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes