### PR TITLE
Hotfix/cache driver bug

### DIFF
--- a/src/Utilities/Cache/CacheFactory.php
+++ b/src/Utilities/Cache/CacheFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Asterios\Core\Utilities\Cache;
 
+use Asterios\Core\Asterios;
 use Asterios\Core\Config;
 use Asterios\Core\Contracts\Utilities\Cache\CacheDriverInterface;
 use Asterios\Core\Contracts\Utilities\Cache\SerializerInterface;
@@ -23,7 +24,7 @@ final class CacheFactory
     {
         $config = Config::get('cache');
 
-        $default = $config->{$configGroup};
+        $default = (object)$config->{$configGroup};
 
         $driver = $default->driver;
         $serializer = $default->serializer;
@@ -48,8 +49,8 @@ final class CacheFactory
             ),
 
             'mysql' => self::mysql(
-                configGroup: $config->mysql->config_group,
-                table: $config->mysql->table,
+                configGroup: $config->mysql['config_group'],
+                table: $config->mysql['table'],
                 serializer: $serializer,
                 prefix: $prefix,
                 defaultTtl: $ttl
@@ -63,7 +64,7 @@ final class CacheFactory
             ),
 
             default => self::file(
-                path: $config->file->path,
+                path: $config->file['path'],
                 serializer: $serializer,
                 prefix: $prefix,
                 defaultTtl: $ttl
@@ -175,18 +176,18 @@ final class CacheFactory
         $redis = new Redis();
 
         $redis->connect(
-            $config->redis->host,
-            (int)$config->redis->port,
-            (float)$config->redis->timeout
+            $config->redis['host'],
+            (int)$config->redis['port'],
+            (float)$config->redis['timeout']
         );
 
-        if (!empty($config->redis->password))
+        if (!empty($config->redis['password']))
         {
-            $redis->auth($config->redis->password);
+            $redis->auth($config->redis['password']);
         }
 
         $redis->select(
-            (int)$config->redis->database
+            (int)$config->redis['database']
         );
 
         return new RedisDriver(
@@ -205,7 +206,7 @@ final class CacheFactory
         $drivers = [];
         $serializerInstance = self::serializer($serializer);
 
-        foreach ($config->chain->drivers as $driver)
+        foreach ($config->chain['drivers'] as $driver)
         {
             $drivers[] = match ($driver)
             {
@@ -221,14 +222,14 @@ final class CacheFactory
                 ),
 
                 'file' => new FileDriver(
-                    cachePath: $config->file->path,
+                    cachePath: Asterios::getBasePath($config->file['path']),
                     serializer: $serializerInstance,
                     prefix: $prefix,
                 ),
 
                 'mysql' => new MySqlDriver(
-                    configGroup: $config->mysql->config_group,
-                    table: $config->mysql->table,
+                    configGroup: $config->mysql['config_group'],
+                    table: $config->mysql['table'],
                     serializer: $serializerInstance,
                     prefix: $prefix,
                 ),

--- a/tests/Cli/Commands/MakeSeederCommandTest.php
+++ b/tests/Cli/Commands/MakeSeederCommandTest.php
@@ -4,7 +4,8 @@ namespace Asterios\Test\Cli\Commands;
 
 use Asterios\Core\Cli\Commands\MakeModelCommand;
 use Asterios\Core\Cli\Commands\MakeSeederCommand;
-use Asterios\Core\Db\Seeder;
+use Asterios\Core\Env;
+use Asterios\Core\Execution\PathResolver;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
@@ -36,10 +37,6 @@ class MakeSeederCommandTest extends MockeryTestCase
     {
         $seederName = 'users';
         $seederPath = '/fake/path/';
-        $expectedFile = $seederPath . $seederName . '.json';
-
-        $mockSeeder = m::mock(Seeder::class);
-        $mockSeeder->shouldReceive('getSeederPath')->once()->andReturn($seederPath);
 
         /** @var MakeModelCommand|m\MockInterface $command */
         $command = m::mock(MakeSeederCommand::class)
@@ -47,9 +44,7 @@ class MakeSeederCommandTest extends MockeryTestCase
             ->shouldAllowMockingProtectedMethods();
 
         $command->shouldReceive('printHeader')->once();
-        $command->shouldReceive('createSeeder')->once()->andReturn($mockSeeder);
-        $command->shouldReceive('ensureDirectoryExists')->once()->with($seederPath);
-        $command->shouldReceive('fileExists')->once()->with($expectedFile)->andReturn(true);
+        $command->shouldReceive('fileExists')->once()->andReturn(true);
         $command->shouldReceive('writeFile')->never();
 
         ob_start();
@@ -61,12 +56,13 @@ class MakeSeederCommandTest extends MockeryTestCase
 
     public function testHandleCreatesSeederFileSuccessfully(): void
     {
-        $seederName = 'users';
+        $seederName = 'users123';
         $seederPath = '/fake/path/';
         $expectedFile = $seederPath . $seederName . '.json';
 
-        $mockSeeder = m::mock(Seeder::class);
-        $mockSeeder->shouldReceive('getSeederPath')->once()->andReturn($seederPath);
+        $pathResolverMock = m::mock(new PAthResolver(new Env()));
+        $pathResolverMock->shouldReceive('resolve')->andReturn($seederPath);
+
 
         /** @var MakeModelCommand|m\MockInterface $command */
         $command = m::mock(MakeSeederCommand::class)
@@ -74,10 +70,8 @@ class MakeSeederCommandTest extends MockeryTestCase
             ->shouldAllowMockingProtectedMethods();
 
         $command->shouldReceive('printHeader')->once();
-        $command->shouldReceive('createSeeder')->once()->andReturn($mockSeeder);
-        $command->shouldReceive('ensureDirectoryExists')->once()->with($seederPath);
-        $command->shouldReceive('fileExists')->once()->with($expectedFile)->andReturn(false);
-        $command->shouldReceive('writeFile')->once()->with($expectedFile, "[]\n");
+        $command->shouldReceive('fileExists')->once()->andReturn(false);
+        $command->shouldReceive('writeFile')->once()->andReturnTrue();
 
         ob_start();
         $command->handle($seederName);


### PR DESCRIPTION
# Task

# Description

<!--- START AUTOGENERATED NOTES --->
# Contents ([#136](https://github.com/asteriosframework/core/pull/136))

### Other
- standardize config property access to array syntax and enhance `file` driver path resolution
- update `MakeSeederCommandTest` to use `PathResolver` and clean up mocks for better test clarity and reliability

<!--- END AUTOGENERATED NOTES --->


# Codecov AI

@codecov-ai-reviewer test
@codecov-ai-reviewer review

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes