### PR TITLE
Security-focused ORM release

### DIFF
--- a/src/Contracts/Orm/ModelInterface.php
+++ b/src/Contracts/Orm/ModelInterface.php
@@ -490,4 +490,13 @@ interface ModelInterface
      * @throws ModelPropertyException
      */
     public function updatePrepared(int|string $id, array $data = []): bool;
+
+    /**
+     * @param array $data
+     * @return false|int|string
+     * @throws ConfigLoadException
+     * @throws ModelException
+     * @throws ModelPropertyException
+     */
+    public function insertPrepared(array $data = []): false|int|string;
 }

--- a/src/Contracts/Orm/ModelInterface.php
+++ b/src/Contracts/Orm/ModelInterface.php
@@ -480,4 +480,14 @@ interface ModelInterface
      * @throws ModelException
      */
     public function getDefault(string $columnName): string|int|float|null;
+
+    /**
+     * @param int|string $id
+     * @param array $data
+     * @return bool
+     * @throws ConfigLoadException
+     * @throws ModelException
+     * @throws ModelPropertyException
+     */
+    public function updatePrepared(int|string $id, array $data = []): bool;
 }

--- a/src/Contracts/Orm/ModelInterface.php
+++ b/src/Contracts/Orm/ModelInterface.php
@@ -162,6 +162,8 @@ interface ModelInterface
     /**
      * @return string|null
      * @throws ModelException
+     *
+     * @deprecated since 2.5.0 Use compilePrepared() internally.
      */
     public function compile(): ?string;
 
@@ -391,6 +393,8 @@ interface ModelInterface
      * @param array $array
      * @return string|false
      * @throws ConfigLoadException
+     *
+     * @deprecated since 2.5.0 Will be removed in 3.0
      */
     public function prepareUpdate(array $array): false|string;
 
@@ -414,6 +418,8 @@ interface ModelInterface
      * @param array $array
      * @return bool|array
      * @throws ConfigLoadException
+     *
+     * @deprecated since 2.5.0 Will be removed in 3.0
      */
     public function prepareInsert(array $array): bool|array;
 

--- a/src/Contracts/Orm/ModelInterface.php
+++ b/src/Contracts/Orm/ModelInterface.php
@@ -9,6 +9,7 @@ use Asterios\Core\Exception\ModelException;
 use Asterios\Core\Exception\ModelInvalidArgumentException;
 use Asterios\Core\Exception\ModelPrimaryKeyException;
 use Asterios\Core\Exception\ModelPropertyException;
+use Asterios\Core\Orm\CompiledQuery;
 
 interface ModelInterface
 {
@@ -146,6 +147,17 @@ interface ModelInterface
      * @throws ConfigLoadException
      */
     public function execute(string $option = self::EXECUTE_MODE_READ): static;
+
+    /**
+     * @return $this
+     * @throws ConfigLoadException
+     */
+    public function executePrepared(): static;
+
+    /**
+     * @return CompiledQuery
+     */
+    public function compilePrepared(): CompiledQuery;
 
     /**
      * @return string|null

--- a/src/Contracts/Orm/OrmQueryBuilderInterface.php
+++ b/src/Contracts/Orm/OrmQueryBuilderInterface.php
@@ -4,6 +4,7 @@ namespace Asterios\Core\Contracts\Orm;
 
 use Asterios\Core\Exception\ModelException;
 use Asterios\Core\Exception\ModelInvalidArgumentException;
+use Asterios\Core\Orm\CompiledQuery;
 
 interface OrmQueryBuilderInterface
 {
@@ -185,6 +186,16 @@ interface OrmQueryBuilderInterface
      * @throws ModelException
      */
     public function compile(): ?string;
+
+    /**
+     * @return array
+     */
+    public function getBindings(): array;
+
+    /**
+     * @return CompiledQuery
+     */
+    public function compilePrepared(): CompiledQuery;
 
     /**
      * @return string|null

--- a/src/Contracts/Orm/OrmQueryBuilderInterface.php
+++ b/src/Contracts/Orm/OrmQueryBuilderInterface.php
@@ -184,6 +184,7 @@ interface OrmQueryBuilderInterface
     /**
      * @return string|null
      * @throws ModelException
+     * @deprecated since 2.5.0 Use compilePrepared() internally.
      */
     public function compile(): ?string;
 

--- a/src/Contracts/Orm/OrmSqlFormatterInterface.php
+++ b/src/Contracts/Orm/OrmSqlFormatterInterface.php
@@ -15,6 +15,8 @@ interface OrmSqlFormatterInterface
     /**
      * @param string|int|float|null|bool $value
      * @return string
+     *
+     * @deprecated since 2.5.0 Only used by legacy SQL builders.
      */
     public function formatValue(string|int|float|null|bool $value): string;
 

--- a/src/Db.php
+++ b/src/Db.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Asterios\Core;
 
+use Asterios\Core\Orm\CompiledQuery;
+use mysqli_stmt;
+
 class Db
 {
     /** @var \mysqli|null */
@@ -398,5 +401,118 @@ class Db
     private function get_charset(): string
     {
         return $this->charset;
+    }
+
+    private static function buildBindingTypes(array $bindings): string
+    {
+        $types = '';
+
+        foreach ($bindings as $binding)
+        {
+            if (is_int($binding))
+            {
+                $types .= 'i';
+            }
+            elseif (is_float($binding))
+            {
+                $types .= 'd';
+            }
+            else
+            {
+                $types .= 's';
+            }
+        }
+
+        return $types;
+    }
+
+    private static function bindStatement(mysqli_stmt $stmt, array $bindings): void
+    {
+        if ($bindings === [])
+        {
+            return;
+        }
+
+        $types = self::buildBindingTypes($bindings);
+
+        $stmt->bind_param(
+            $types,
+            ...$bindings
+        );
+    }
+
+    /**
+     * @param CompiledQuery $query
+     * @param string $config_group
+     * @return array|bool
+     * @throws Exception\ConfigLoadException
+     */
+    public static function readPrepared(CompiledQuery $query, string $config_group = 'default'): array|bool
+    {
+        $connection = self::forge($config_group)->get_connection();
+        $stmt = $connection->prepare($query->sql);
+
+        if ($stmt === false)
+        {
+            return false;
+        }
+
+        if (!empty($query->bindings))
+        {
+            self::bindStatement($stmt, $query->bindings);
+        }
+
+        if (!$stmt->execute())
+        {
+            $stmt->close();
+
+            return false;
+        }
+
+        $result = $stmt->get_result();
+
+        $result_array = [];
+
+        if ($result !== false)
+        {
+            while ($row = $result->fetch_assoc())
+            {
+                $result_array[] = $row;
+            }
+
+            $result->free();
+        }
+
+        $stmt->close();
+
+        return !empty($result_array) ? $result_array : false;
+    }
+
+    /**
+     * @param CompiledQuery $query
+     * @param string $config_group
+     * @return bool
+     * @throws Exception\ConfigLoadException
+     */
+    public static function writePrepared(CompiledQuery $query, string $config_group = 'default'): bool
+    {
+        $connection = self::forge($config_group)->get_connection();
+        $stmt = $connection->prepare($query->sql);
+
+        if ($stmt === false)
+        {
+            return false;
+        }
+
+        if ($query->hasBindings())
+        {
+            self::bindStatement($stmt, $query->bindings);
+        }
+
+        $result = $stmt->execute();
+
+        $stmt->close();
+
+        return $result;
     }
 }

--- a/src/Db.php
+++ b/src/Db.php
@@ -128,6 +128,42 @@ class Db
     }
 
     /**
+     * @param CompiledQuery $query
+     * @param string $config_group
+     * @return false|int|string
+     * @throws Exception\ConfigLoadException
+     */
+    public static function insertPrepared(CompiledQuery $query, string $config_group = 'default'): false|int|string
+    {
+        $connection = self::forge($config_group)->get_connection();
+
+        $stmt = $connection->prepare($query->sql);
+
+        if ($stmt === false)
+        {
+            return false;
+        }
+
+        if ($query->hasBindings())
+        {
+            self::bindStatement($stmt, $query->bindings);
+        }
+
+        if (!$stmt->execute())
+        {
+            $stmt->close();
+
+            return false;
+        }
+
+        $insertId = $connection->insert_id;
+
+        $stmt->close();
+
+        return $insertId;
+    }
+
+    /**
      * @throws Exception\ConfigLoadException
      */
     public static function escape(string $value, string $config_group = 'default'): string

--- a/src/Model.php
+++ b/src/Model.php
@@ -1412,4 +1412,52 @@ class Model implements ModelInterface
             $this->connection
         );
     }
+
+    /**
+     * @param array $data
+     * @return CompiledQuery
+     * @throws ModelException
+     */
+    protected function compileInsertPrepared(array $data): CompiledQuery
+    {
+        $columns = [];
+        $placeholders = [];
+        $bindings = [];
+
+        foreach ($data as $column => $value)
+        {
+            $columns[] =
+                $this->formatter->backticks($column);
+
+            $placeholders[] = '?';
+
+            $bindings[] = $value;
+        }
+
+        $sql =
+            'INSERT INTO '
+            . $this->table()
+            . ' ('
+            . implode(', ', $columns)
+            . ') VALUES ('
+            . implode(', ', $placeholders)
+            . ')';
+
+        return new CompiledQuery($sql, $bindings);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function insertPrepared(array $data = []): false|int|string
+    {
+        if (empty($data))
+        {
+            return false;
+        }
+
+        $this->hasProperties($data);
+
+        return Db::insertPrepared($this->compileInsertPrepared($data), $this->connection);
+    }
 }

--- a/src/Model.php
+++ b/src/Model.php
@@ -1322,4 +1322,37 @@ class Model implements ModelInterface
 
         return $this->properties[$columnName]['default'];
     }
+
+    /**
+     * @param int|string $id
+     * @return CompiledQuery
+     * @throws ModelException
+     */
+    protected function compileDeletePrepared(int|string $id): CompiledQuery
+    {
+        return new CompiledQuery(
+            sprintf(
+                'DELETE FROM %s WHERE %s = ?',
+                $this->table(),
+                $this->formatter->backticks(
+                    $this->primaryKey()
+                )
+            ),
+            [$id]
+        );
+    }
+
+    /**
+     * @param int|string $id
+     * @return bool
+     * @throws ConfigLoadException
+     * @throws ModelException
+     */
+    public function deletePrepared(int|string $id): bool
+    {
+        return Db::writePrepared(
+            $this->compileDeletePrepared($id),
+            $this->connection
+        );
+    }
 }

--- a/src/Model.php
+++ b/src/Model.php
@@ -12,6 +12,7 @@ use Asterios\Core\Exception\ModelException;
 use Asterios\Core\Exception\ModelInvalidArgumentException;
 use Asterios\Core\Exception\ModelPrimaryKeyException;
 use Asterios\Core\Exception\ModelPropertyException;
+use Asterios\Core\Orm\CompiledQuery;
 use Asterios\Core\Orm\OrmMetadata;
 use Asterios\Core\Orm\OrmQueryBuilder;
 use Asterios\Core\Orm\OrmSqlFormatter;
@@ -208,9 +209,30 @@ class Model implements ModelInterface
     /**
      * @inheritDoc
      */
+    public function executePrepared(): static
+    {
+        $this->result = Db::readPrepared(
+            $this->compilePrepared(),
+            $this->connection
+        );
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function compile(): ?string
     {
         return $this->queryBuilder->compile();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function compilePrepared(): CompiledQuery
+    {
+        return $this->queryBuilder->compilePrepared();
     }
 
     /**

--- a/src/Model.php
+++ b/src/Model.php
@@ -201,7 +201,7 @@ class Model implements ModelInterface
             return $this;
         }
 
-        $this->result = Db::read($this->compile(), $this->connection);
+        $this->result = Db::readPrepared($this->compilePrepared(), $this->connection);
 
         return $this;
     }
@@ -991,16 +991,7 @@ class Model implements ModelInterface
         }
 
         $this->hasProperties($data);
-        $insert_data = $this->prepareInsert($data);
-
-        $sql = 'INSERT INTO
-                    ' . $this->table() . '
-                    ' . $insert_data[0] . '
-                         VALUES
-                    ' . $insert_data[1] . '
-                ';
-
-        return Db::insert($sql, $this->connection);
+        return Db::insertPrepared($this->compileInsertPrepared($data), $this->connection);
     }
 
     /**

--- a/src/Model.php
+++ b/src/Model.php
@@ -1355,4 +1355,61 @@ class Model implements ModelInterface
             $this->connection
         );
     }
+
+    /**
+     * @param int|string $id
+     * @param array $data
+     * @return CompiledQuery
+     * @throws ModelException
+     */
+    protected function compileUpdatePrepared(int|string $id, array $data): CompiledQuery
+    {
+        $bindings = [];
+        $setParts = [];
+
+        foreach ($data as $column => $value)
+        {
+            $setParts[] =
+                $this->formatter->backticks($column)
+                . ' = ?';
+
+            $bindings[] = $value;
+        }
+
+        $bindings[] = $id;
+
+        $sql =
+            'UPDATE '
+            . $this->table()
+            . ' SET '
+            . implode(', ', $setParts)
+            . ' WHERE '
+            . $this->formatter->backticks(
+                $this->primaryKey()
+            )
+            . ' = ?';
+
+        return new CompiledQuery($sql, $bindings);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function updatePrepared(int|string $id, array $data = []): bool
+    {
+        if (empty($data))
+        {
+            return false;
+        }
+
+        $this->hasProperties($data);
+
+        return Db::writePrepared(
+            $this->compileUpdatePrepared(
+                $id,
+                $data
+            ),
+            $this->connection
+        );
+    }
 }

--- a/src/Model.php
+++ b/src/Model.php
@@ -916,10 +916,7 @@ class Model implements ModelInterface
 
         $this->hasProperties($data);
 
-        $sql = 'UPDATE ' . $this->table() . ' SET ' . $this->prepareUpdate($data) . ' WHERE ' . $this->formatter->backticks($this->primaryKey()) . ' = ' .
-            $id;
-
-        return Db::write($sql, $this->connection);
+        return Db::writePrepared($this->compileUpdatePrepared($id, $data), $this->connection);
     }
 
     /**
@@ -939,6 +936,7 @@ class Model implements ModelInterface
 
     /**
      * @inheritDoc
+     * @deprecated since 2.5.0 Legacy SQL string builder.
      */
     public function prepareUpdate(array $array): false|string
     {
@@ -996,6 +994,7 @@ class Model implements ModelInterface
 
     /**
      * @inheritDoc
+     * @deprecated since 2.5.0 Legacy SQL string builder.
      */
     public function prepareInsert(array $array): bool|array
     {

--- a/src/Orm/CompiledQuery.php
+++ b/src/Orm/CompiledQuery.php
@@ -13,6 +13,8 @@ final class CompiledQuery extends Data
     /** @var list<int|float|string|bool|null> */
     public array $bindings = [];
 
+    public bool $prepared = true;
+
     public function __construct(
         string $sql = '',
         array $bindings = []

--- a/src/Orm/CompiledQuery.php
+++ b/src/Orm/CompiledQuery.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Asterios\Core\Orm;
+
+use Asterios\Core\Data;
+
+final class CompiledQuery extends Data
+{
+    public string $sql = '';
+
+    /** @var list<int|float|string|bool|null> */
+    public array $bindings = [];
+
+    public function __construct(
+        string $sql = '',
+        array $bindings = []
+    ) {
+        $this->sql = $sql;
+        $this->bindings = $bindings;
+    }
+
+    public function hasBindings(): bool
+    {
+        return $this->bindings !== [];
+    }
+}

--- a/src/Orm/OrmQueryBuilder.php
+++ b/src/Orm/OrmQueryBuilder.php
@@ -319,7 +319,8 @@ final class OrmQueryBuilder implements OrmQueryBuilderInterface
         $new->whereParts[] = [
             'type' => 'raw',
             'boolean' => $new->nextBoolean,
-            'expression' => $expr,
+            'expression' => "MATCH($cols) AGAINST (?$mode)",
+            'bindings' => [$search],
         ];
 
         $new->nextBoolean = 'AND';
@@ -432,8 +433,15 @@ final class OrmQueryBuilder implements OrmQueryBuilderInterface
             }
             elseif ($part['type'] === 'raw')
             {
-
                 $sql .= $part['expression'];
+
+                if (!empty($part['bindings']))
+                {
+                    foreach ($part['bindings'] as $binding)
+                    {
+                        $this->bindings[] = $binding;
+                    }
+                }
             }
 
             $previousWasOpenBracket = false;

--- a/src/Orm/OrmQueryBuilder.php
+++ b/src/Orm/OrmQueryBuilder.php
@@ -22,6 +22,7 @@ final class OrmQueryBuilder implements OrmQueryBuilderInterface
 
     private ?string $rawQuery = null;
     private string $nextBoolean = 'AND';
+    private array $bindings = [];
 
     public function __construct(
         private readonly OrmMetadata $metadata,
@@ -324,6 +325,122 @@ final class OrmQueryBuilder implements OrmQueryBuilderInterface
         $new->nextBoolean = 'AND';
 
         return $new;
+    }
+
+    /** @inheritDoc */
+    public function getBindings(): array
+    {
+        return $this->bindings;
+    }
+
+    /** @inheritDoc */
+    public function compilePrepared(): CompiledQuery
+    {
+        $builder = clone $this;
+
+        $builder->bindings = [];
+
+        $sql = 'SELECT ';
+
+        if ($builder->distinct)
+        {
+            $sql .= 'DISTINCT ';
+        }
+
+        $sql .= $builder->compileSelect();
+        $sql .= $builder->compileFrom();
+        $sql .= $builder->compileJoins();
+        $sql .= $builder->compileWherePrepared();
+        $sql .= $builder->compileGroupBy();
+        $sql .= $builder->compileOrderBy();
+        $sql .= $builder->compileLimit();
+
+        return new CompiledQuery(
+            trim($sql),
+            $builder->bindings
+        );
+    }
+
+    private function compileWherePrepared(): string
+    {
+        if (empty($this->whereParts))
+        {
+            return '';
+        }
+
+        $sql = ' WHERE ';
+        $first = true;
+        $previousWasOpenBracket = false;
+
+        foreach ($this->whereParts as $part)
+        {
+
+            if ($part['type'] === 'bracket')
+            {
+
+                if ($part['value'] === '(')
+                {
+
+                    if (!$first)
+                    {
+                        $sql .= ' ' . $part['boolean'] . ' ';
+                    }
+
+                    $sql .= '(';
+                    $previousWasOpenBracket = true;
+                    $first = false;
+                    continue;
+                }
+
+                if ($part['value'] === ')')
+                {
+                    $sql .= ')';
+                    $previousWasOpenBracket = false;
+                    continue;
+                }
+            }
+
+            if (!$first && !$previousWasOpenBracket)
+            {
+                $sql .= ' ' . ($part['boolean'] ?? 'AND') . ' ';
+            }
+
+            if ($part['type'] === 'condition')
+            {
+
+                $column = $part['backticks']
+                    ? $this->formatter->backticks($part['column'])
+                    : $part['column'];
+
+                $sql .= $column . ' ' . $part['operator'];
+
+                if (!$this->formatter->isOperatorNull($part['operator']))
+                {
+
+                    if ($part['formatValue'])
+                    {
+                        $sql .= ' ?';
+
+                        $this->bindings[] = $part['value'];
+                    }
+                    else
+                    {
+                        $sql .= ' ' . $part['value'];
+                    }
+                }
+
+            }
+            elseif ($part['type'] === 'raw')
+            {
+
+                $sql .= $part['expression'];
+            }
+
+            $previousWasOpenBracket = false;
+            $first = false;
+        }
+
+        return $sql;
     }
 
     /** @inheritDoc */


### PR DESCRIPTION
# ORM Migration to Prepared Statements

## The ORM has been internally migrated to prepared statements.

SELECT, INSERT, UPDATE, and DELETE operations now use parameter binding by default.
Full-text search queries in the prepared execution path are now secured as well.
Improved protection against SQL injection attacks.
Fully backward compatible with existing applications and ORM APIs.

<!--- START AUTOGENERATED NOTES --->
# Contents ([#138](https://github.com/asteriosframework/core/pull/138))

### Other
- add support for prepared query compilation with bindings
- add prepared statement execution path
- add support for prepared statement execution
- add `prepared` property to `CompiledQuery` for prepared statement tracking
- add `updatePrepared` method for prepared statement updates
- add `insertPrepared` method for prepared statement inserts
- replace raw queries with prepared statement methods for `read` and `insert`
- deprecate legacy SQL builder APIs
- add full-text search support with bindings in `OrmQueryBuilder`

<!--- END AUTOGENERATED NOTES --->


# Codecov AI

@codecov-ai-reviewer test
@codecov-ai-reviewer review

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes