### PR TITLE
fix(cli): improve autoload file resolution logic

### DIFF
--- a/bin/asterios
+++ b/bin/asterios
@@ -4,21 +4,21 @@
 use Asterios\Core\Cli\Builder\ColorBuilder;
 use Asterios\Core\Cli\CommandRegistry;
 
-$localAutoload = getcwd() . '/vendor/autoload.php';
-$globalAutoload = __DIR__ . '/../vendor/autoload.php';
-
-if (file_exists($localAutoload))
+if (isset($GLOBALS['_composer_autoload_path']) && file_exists($GLOBALS['_composer_autoload_path']))
 {
-    require $localAutoload;
-}
-elseif (file_exists($globalAutoload))
-{
-    require $globalAutoload;
+    require $GLOBALS['_composer_autoload_path'];
 }
 else
 {
-    echo "Autoload file not found.\n";
-    exit(1);
+    $autoload = dirname(__DIR__, 3) . '/autoload.php';
+
+    if (!file_exists($autoload))
+    {
+        fwrite(STDERR, "Autoload file not found: {$autoload}\n");
+        exit(1);
+    }
+
+    require $autoload;
 }
 
 


### PR DESCRIPTION
- Updated autoload resolution to use the global `_composer_autoload_path` if available.
- Fallback to a relative autoload file path with enhanced error handling and clear STDERR messaging.

# Task

# Description

<!--- START AUTOGENERATED NOTES --->
# Contents ([#142](https://github.com/asteriosframework/core/pull/142))

### Other
- improve autoload file resolution logic

<!--- END AUTOGENERATED NOTES --->


# Codecov AI

@codecov-ai-reviewer test
@codecov-ai-reviewer review

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes