### PR TITLE
fix(cli): remove redundant base path call in `CommandRegistry`

### DIFF
--- a/src/Cli/CommandRegistry.php
+++ b/src/Cli/CommandRegistry.php
@@ -141,7 +141,7 @@ class CommandRegistry extends AbstractFileExecutor implements CommandRegistryInt
     {
         try
         {
-            return Asterios::getBasePath() . $this->pathResolver->commands();
+            return $this->pathResolver->commands();
         }
         catch (\Throwable)
         {


### PR DESCRIPTION
# Task

# Description

<!--- START AUTOGENERATED NOTES --->
# Contents ([#144](https://github.com/asteriosframework/core/pull/144))

### Other
- remove redundant base path call in `CommandRegistry`

<!--- END AUTOGENERATED NOTES --->


# Codecov AI

@codecov-ai-reviewer test
@codecov-ai-reviewer review

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes