### PR TITLE
feat(cli): introduce `CliBaseCommandException` and enhance `BaseComma…

### DIFF
--- a/src/Cli/Base/BaseCommand.php
+++ b/src/Cli/Base/BaseCommand.php
@@ -2,10 +2,16 @@
 
 namespace Asterios\Core\Cli\Base;
 
+use Asterios\Core\Asterios;
 use Asterios\Core\Cli\Attributes\Command;
 use Asterios\Core\Cli\Builder\ColorBuilder;
+use Asterios\Core\Cli\Exception\CliBaseCommandException;
 use Asterios\Core\Cli\Support\ArgumentParserTrait;
+use Asterios\Core\Config;
 use Asterios\Core\Contracts\CommandInterface;
+use Asterios\Core\Exception\AsteriosException;
+use Asterios\Core\Exception\ConfigLoadException;
+use Asterios\Core\Security\TwoFactor\Passkey\Exception\ChallengeServiceException;
 use Asterios\Core\Traits\Cli\Commands\CommandsBuilderTrait;
 use ReflectionException;
 
@@ -14,10 +20,22 @@ abstract class BaseCommand implements CommandInterface
     use CommandsBuilderTrait;
     use ArgumentParserTrait;
 
+    /**
+     * @throws CliBaseCommandException
+     */
     // @codeCoverageIgnoreStart
     public function __construct()
     {
         $this->parseArguments();
+
+        try {
+            Config::set_config_path(getcwd() . '/config');
+            Asterios::init();
+        } catch (ConfigLoadException|ConfigLoadException $e) {
+            throw new CliBaseCommandException(message: 'Unable to load Config in BaseCommand.', previous: $e);
+        } catch (AsteriosException $e) {
+            throw new CliBaseCommandException(message: 'Unable to initialize Asterios n aseCommand.', previous: $e);
+        }
     }
 
     // @codeCoverageIgnoreEnd

--- a/src/Cli/Exception/CliBaseCommandException.php
+++ b/src/Cli/Exception/CliBaseCommandException.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Asterios\Core\Cli\Exception;
+
+use Asterios\Core\Exception\AsteriosException;
+
+class CliBaseCommandException extends AsteriosException {
+
+}


### PR DESCRIPTION
…nd` initialization

- Added `CliBaseCommandException` to standardize exception handling in CLI commands.
- Enhanced `BaseCommand` constructor to initialize `Asterios` and load configuration with improved error handling.

# Task

# Description

<!--- START AUTOGENERATED NOTES --->
# Contents ([#146](https://github.com/asteriosframework/core/pull/146))

### Other
- introduce `CliBaseCommandException` and enhance `BaseCommand` initialization

<!--- END AUTOGENERATED NOTES --->


# Codecov AI

@codecov-ai-reviewer test
@codecov-ai-reviewer review

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes