### PR TITLE
Merge feature/http-query into develop

### DIFF
--- a/src/Contracts/RouteInterface.php
+++ b/src/Contracts/RouteInterface.php
@@ -26,6 +26,14 @@ interface RouteInterface
      * @param array $options
      * @return void
      */
+    public static function query(string $uri, string|array $action, array $options = []): void;
+
+    /**
+     * @param string $uri
+     * @param string|array $action
+     * @param array $options
+     * @return void
+     */
     public static function put(string $uri, string|array $action, array $options = []): void;
 
     /**

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -4,11 +4,14 @@ namespace Asterios\Core;
 
 use Asterios\Core\Http\ContentType;
 use Asterios\Core\Http\Disposition;
+use Asterios\Core\Http\ServerRequest;
 use JsonException;
 
 class Controller
 {
     private string $contentType = ContentType::JSON;
+
+    protected ServerRequest $request;
 
     private ?string $contentDisposition = null;
 
@@ -79,7 +82,7 @@ class Controller
 
     public function __construct()
     {
-
+        $this->request = new ServerRequest();
     }
 
     /**
@@ -227,5 +230,27 @@ class Controller
     public function attachment(?string $filename = null): self
     {
         return $this->setContentDisposition(Disposition::ATTACHMENT, $filename);
+    }
+
+    /**
+     * @return ServerRequest
+     */
+    public function request(): ServerRequest
+    {
+        return $this->request;
+    }
+
+    /**
+     * @return array|object|null
+     * @throws JsonException
+     */
+    protected function json(): array|object|null
+    {
+        return $this->request->json();
+    }
+
+    protected function body(): string
+    {
+        return $this->request->body();
     }
 }

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -1,0 +1,239 @@
+<?php declare(strict_types=1);
+
+namespace Asterios\Core\Http;
+
+use JsonException;
+
+class ServerRequest
+{
+    private ?string $body = null;
+
+    /**
+     * Returns the HTTP request method.
+     */
+    public function method(): string
+    {
+        return strtoupper($_SERVER['REQUEST_METHOD'] ?? 'GET');
+    }
+
+    /**
+     * Returns whether the current request uses the given HTTP method.
+     */
+    public function isMethod(string $method): bool
+    {
+        return $this->method() === strtoupper($method);
+    }
+
+    public function isGet(): bool
+    {
+        return $this->isMethod('GET');
+    }
+
+    public function isPost(): bool
+    {
+        return $this->isMethod('POST');
+    }
+
+    public function isPut(): bool
+    {
+        return $this->isMethod('PUT');
+    }
+
+    public function isPatch(): bool
+    {
+        return $this->isMethod('PATCH');
+    }
+
+    public function isDelete(): bool
+    {
+        return $this->isMethod('DELETE');
+    }
+
+    public function isOptions(): bool
+    {
+        return $this->isMethod('OPTIONS');
+    }
+
+    public function isHead(): bool
+    {
+        return $this->isMethod('HEAD');
+    }
+
+    public function isQuery(): bool
+    {
+        return $this->isMethod('QUERY');
+    }
+
+    /**
+     * Returns the raw request body.
+     */
+    public function body(): string
+    {
+        if ($this->body === null)
+        {
+            $this->body = file_get_contents('php://input') ?: '';
+        }
+
+        return $this->body;
+    }
+
+    /**
+     * Returns the decoded JSON body.
+     *
+     * @throws JsonException
+     */
+    public function json(bool $associative = true): array|object|null
+    {
+        $body = $this->body();
+
+        if ($body === '')
+        {
+            return $associative ? [] : null;
+        }
+
+        return json_decode(
+            $body,
+            $associative,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+    }
+
+    /**
+     * Returns all query parameters or a single value.
+     */
+    public function query(?string $key = null, mixed $default = null): mixed
+    {
+        if ($key === null)
+        {
+            return $_GET;
+        }
+
+        return $_GET[$key] ?? $default;
+    }
+
+    /**
+     * Returns all POST parameters or a single value.
+     *
+     * Mainly for backwards compatibility with HTML forms.
+     */
+    public function post(?string $key = null, mixed $default = null): mixed
+    {
+        if ($key === null)
+        {
+            return $_POST;
+        }
+
+        return $_POST[$key] ?? $default;
+    }
+
+    /**
+     * Returns all uploaded files or a single file.
+     */
+    public function files(?string $key = null): mixed
+    {
+        if ($key === null)
+        {
+            return $_FILES;
+        }
+
+        return $_FILES[$key] ?? null;
+    }
+
+    /**
+     * Returns all cookies or a single cookie.
+     */
+    public function cookie(?string $key = null, mixed $default = null): mixed
+    {
+        if ($key === null)
+        {
+            return $_COOKIE;
+        }
+
+        return $_COOKIE[$key] ?? $default;
+    }
+
+    /**
+     * Returns all server variables or a single value.
+     */
+    public function server(?string $key = null, mixed $default = null): mixed
+    {
+        if ($key === null)
+        {
+            return $_SERVER;
+        }
+
+        return $_SERVER[$key] ?? $default;
+    }
+
+    /**
+     * Returns all request headers.
+     */
+    public function headers(): array
+    {
+        if (function_exists('getallheaders'))
+        {
+            return getallheaders();
+        }
+
+        $headers = [];
+
+        foreach ($_SERVER as $name => $value)
+        {
+            if (str_starts_with($name, 'HTTP_'))
+            {
+                $header = str_replace('_', '-', substr($name, 5));
+                $headers[$header] = $value;
+            }
+        }
+
+        return $headers;
+    }
+
+    /**
+     * Returns a single request header.
+     */
+    public function header(string $name, mixed $default = null): mixed
+    {
+        $headers = $this->headers();
+
+        foreach ($headers as $header => $value)
+        {
+            if (strcasecmp($header, $name) === 0)
+            {
+                return $value;
+            }
+        }
+
+        return $default;
+    }
+
+    /**
+     * Returns the request URI.
+     */
+    public function uri(): string
+    {
+        return $_SERVER['REQUEST_URI'] ?? '/';
+    }
+
+    /**
+     * Returns the request path without query string.
+     */
+    public function path(): string
+    {
+        return parse_url($this->uri(), PHP_URL_PATH) ?: '/';
+    }
+
+    /**
+     * Returns whether the request body contains JSON.
+     */
+    public function isJson(): bool
+    {
+        $contentType = $this->header('Content-Type', '');
+
+        return str_contains(
+            strtolower((string)$contentType),
+            'application/json'
+        );
+    }
+}

--- a/src/Request.php
+++ b/src/Request.php
@@ -9,42 +9,42 @@ class Request
      *
      * @var string
      **/
-    public $cookie_file;
+    public string $cookie_file;
 
     /**
      * Determines whether requests should follow redirects
      *
      * @var boolean
      **/
-    public $follow_redirects = true;
+    public bool $follow_redirects = true;
 
     /**
      * An associative array of headers to send along with requests
      *
      * @var array
      **/
-    public $headers = [];
+    public array $headers = [];
 
     /**
      * An associative array of CURL-OPT options to send along with requests
      *
      * @var array
      **/
-    public $options = [];
+    public array $options = [];
 
     /**
      * The referer header to send along with requests
      *
      * @var string
      **/
-    public $referer;
+    public string $referer;
 
     /**
      * The user agent to send along with requests
      *
      * @var string
      **/
-    public $user_agent;
+    public string $user_agent;
 
     /**
      * Stores an error string for the last request if one occurred
@@ -52,10 +52,10 @@ class Request
      * @var string
      * @access protected
      **/
-    protected $error = '';
+    protected string $error = '';
 
     /** @var mixed */
-    protected $request;
+    protected mixed $request;
 
     /**
      * Initializes a Curl object
@@ -76,9 +76,9 @@ class Request
      *
      * @param string $url
      * @param array|string $vars
-     * @return Response object
-     **/
-    public function delete(string $url, $vars = [])
+     * @return Response|bool object
+     */
+    public function delete(string $url, array|string $vars = []): Response|bool
     {
         return $this->request('DELETE', $url, $vars);
     }
@@ -98,9 +98,9 @@ class Request
      *
      * @param string $url
      * @param array|string $vars
-     * @return Response
-     **/
-    public function get(string $url, $vars = [])
+     * @return Response|bool
+     */
+    public function get(string $url, array|string $vars = []): Response|bool
     {
         if (!empty($vars))
         {
@@ -118,9 +118,9 @@ class Request
      *
      * @param string $url
      * @param array|string $vars
-     * @return Response
-     **/
-    public function head($url, $vars = [])
+     * @return Response|bool
+     */
+    public function head(string $url,  array|string $vars = []): Response|bool
     {
         return $this->request('HEAD', $url, $vars);
     }
@@ -132,9 +132,21 @@ class Request
      * @param array|string $vars
      * @return Response|boolean
      **/
-    public function post($url, $vars = [])
+    public function post(string $url,  array|string $vars = []): Response|bool
     {
         return $this->request('POST', $url, $vars);
+    }
+
+    /**
+     * Makes an HTTP POST request to the specified $url with an optional array or string of $vars
+     *
+     * @param string $url
+     * @param array|string $vars
+     * @return Response|boolean
+     **/
+    public function query(string $url, array|string $vars = []): Response|bool
+    {
+        return $this->request('QUERY', $url, $vars);
     }
 
     /**
@@ -146,7 +158,7 @@ class Request
      * @param array|string $vars
      * @return Response|boolean
      **/
-    public function put($url, $vars = [])
+    public function put(string $url,  array|string $vars = []): Response|bool
     {
         return $this->request('PUT', $url, $vars);
     }
@@ -161,10 +173,11 @@ class Request
      * @param array|string $vars
      * @return Response|boolean
      **/
-    public function request(string $method, string $url, $vars = [])
+    public function request(string $method, string $url, array|string $vars = []): Response|bool
     {
         $this->error = '';
         $this->request = curl_init();
+
         if (is_array($vars))
         {
             $vars = http_build_query($vars);

--- a/src/Router.php
+++ b/src/Router.php
@@ -85,14 +85,24 @@ class Router implements RouterInterface
 
         if ($countHandled === 0)
         {
-            http_response_code(404);
+            if ($this->routeExistsForAnotherMethod($this->getCurrentUri()))
+            {
+                $allowed = $this->getAllowedMethods($this->getCurrentUri());
+
+                header('Allow: ' . implode(', ', $allowed));
+                http_response_code(405);
+            }
+            else
+            {
+                http_response_code(404);
+            }
         }
         elseif ($callback)
         {
             $callback();
         }
 
-        if ($_SERVER['REQUEST_METHOD'] === 'HEAD')
+        if (($_SERVER['REQUEST_METHOD'] ?? '') === 'HEAD')
         {
             ob_end_clean();
         }
@@ -115,10 +125,10 @@ class Router implements RouterInterface
         elseif ($method === 'POST')
         {
             $headers = $this->getRequestHeaders();
-            if (isset($headers['X-HTTP-Method-Override']) &&
-                in_array($headers['X-HTTP-Method-Override'], ['PUT', 'DELETE', 'PATCH'], true))
+            $override = strtoupper(trim($headers['X-HTTP-Method-Override'] ?? ''));
+            if (in_array($override, ['PUT', 'PATCH', 'DELETE', 'QUERY'], true))
             {
-                $method = $headers['X-HTTP-Method-Override'];
+                $method = $override;
             }
         }
 
@@ -215,7 +225,7 @@ class Router implements RouterInterface
     {
         if (is_callable($fn))
         {
-            call_user_func_array($fn, $params);
+            $fn(...$params);
             return;
         }
 
@@ -234,17 +244,17 @@ class Router implements RouterInterface
                 return;
             }
 
-            if (!method_exists($instance, $method))
+            $altMethod = strtolower($this->requestedMethod) . '_' . $method;
+
+            if (method_exists($instance, $altMethod))
             {
-                $altMethod = strtolower($this->requestedMethod) . '_' . $method;
-                if (method_exists($instance, $altMethod))
-                {
-                    $method = $altMethod;
-                }
-                else
-                {
-                    throw new RouterException('Method '.$method.' not found in '.$controller.'.');
-                }
+                $method = $altMethod;
+            }
+            elseif (!method_exists($instance, $method))
+            {
+                throw new RouterException(
+                    'Method ' . $method . ' not found in ' . $controller . '.'
+                );
             }
 
             $instance->$method(...$params);
@@ -322,5 +332,59 @@ class Router implements RouterInterface
         }
 
         return true;
+    }
+
+    /**
+     * @param string $uri
+     * @return bool
+     */
+    private function routeExistsForAnotherMethod(string $uri): bool
+    {
+        foreach ($this->afterRoutes as $method => $routes)
+        {
+            if ($method === $this->requestedMethod)
+            {
+                continue;
+            }
+
+            foreach ($routes as $route)
+            {
+                $pattern = preg_replace('/{(\w+)}/', '([^/]+)', $route['pattern']);
+
+                if ($pattern !== null && preg_match('#^' . $pattern . '$#', $uri))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $uri
+     * @return array
+     */
+    private function getAllowedMethods(string $uri): array
+    {
+        $methods = [];
+
+        foreach ($this->afterRoutes as $method => $routes)
+        {
+            foreach ($routes as $route)
+            {
+                $pattern = preg_replace('/{(\w+)}/', '([^/]+)', $route['pattern']);
+
+                if ($pattern !== null && preg_match('#^' . $pattern . '$#', $uri))
+                {
+                    $methods[] = $method;
+                    break;
+                }
+            }
+        }
+
+        sort($methods);
+
+        return array_unique($methods);
     }
 }

--- a/src/Support/Route.php
+++ b/src/Support/Route.php
@@ -30,6 +30,14 @@ class Route implements RouteInterface
     /**
      * @inheritDoc
      */
+    public static function query(string $uri, string|array $action, array $options = []): void
+    {
+        self::addRoute('QUERY', $uri, $action, $options);
+    }
+
+    /**
+     * @inheritDoc
+     */
     public static function put(string $uri, string|array $action, array $options = []): void
     {
         self::addRoute('PUT', $uri, $action, $options);

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -107,4 +107,13 @@ class RouteTest extends TestCase
         $this->assertContains('index', $routeNames);
         $this->assertContains('destroy', $routeNames);
     }
+
+    public function testQueryAddsRoute(): void
+    {
+        Route::query('search', 'SearchController@index');
+        $route = Route::$routes[0];
+
+        $this->assertSame('QUERY', $route['method']);
+        $this->assertSame('/search', $route['route']);
+    }
 }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -142,4 +142,53 @@ class RouterTest extends TestCase
         $this->assertTrue($result);
         $this->assertEmpty($output);
     }
+
+    public function testRequestMethodQuery(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'QUERY';
+
+        $router = new Router();
+
+        $this->assertSame('QUERY', $router->getRequestMethod());
+    }
+
+    public function testMethodNotAllowedReturns405(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_SERVER['REQUEST_URI'] = '/v1';
+
+        $router = new Router();
+        $router->setMiddlewareNamespace('Asterios\\Test\\Stubs');
+
+        ob_start();
+        $success = $router->run();
+        ob_end_clean();
+
+        $this->assertFalse($success);
+        $this->assertSame(405, http_response_code());
+    }
+
+    public function testSuccessfulQueryRouteExecution(): void
+    {
+        require_once __DIR__ . '/Stubs/AuthMiddleware.php';
+        require_once __DIR__ . '/Stubs/VersionMiddleware.php';
+        require_once __DIR__ . '/Stubs/IndexController.php';
+
+        Route::$routes = [];
+
+        Route::query('/', [IndexController::class, 'index']);
+
+        $_SERVER['REQUEST_METHOD'] = 'QUERY';
+        $_SERVER['REQUEST_URI'] = '/';
+
+        $router = new Router();
+        $router->setMiddlewareNamespace('Asterios\\Test\\Stubs');
+
+        ob_start();
+        $success = $router->run();
+        $output = ob_get_clean();
+
+        $this->assertTrue($success);
+        $this->assertSame('IndexController@query_index', trim($output));
+    }
 }

--- a/tests/Stubs/IndexController.php
+++ b/tests/Stubs/IndexController.php
@@ -8,4 +8,9 @@ class IndexController
     {
         echo 'IndexController@index';
     }
+
+    public function query_index(): void
+    {
+        echo 'IndexController@query_index';
+    }
 }


### PR DESCRIPTION
This merge introduces full support for the HTTP QUERY method (RFC 10008).

Highlights

- HTTP QUERY routing support
- ServerRequest abstraction for incoming requests
- QUERY support in the HTTP client
- query_* controller method resolution
- RFC-compliant 405 Method Not Allowed responses
- Allow response header
- Extended test coverage

This feature is fully backwards compatible.

<!--- START AUTOGENERATED NOTES --->
# Contents ([#165](https://github.com/asteriosframework/core/pull/165))

### Other
- add HTTP QUERY (RFC 10008) support

<!--- END AUTOGENERATED NOTES --->


# Codecov AI

@codecov-ai-reviewer test
@codecov-ai-reviewer review

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes