### PR TITLE
Add support for plain text and multipart emails

### DIFF
--- a/src/Contracts/Mailer/MailServiceInterface.php
+++ b/src/Contracts/Mailer/MailServiceInterface.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Asterios\Core\Contracts\Mailer;
+
+interface MailServiceInterface
+{
+    /**
+     * @param string|array $to
+     * @param string $subject
+     * @param string|null $template
+     * @param array $context
+     * @param string|null $htmlBody
+     * @param string|null $plainText
+     * @param array $attachments
+     * @return bool
+     */
+    public function send(string|array $to, string $subject, ?string $template = null, array $context = [], ?string $htmlBody = null, ?string $plainText = null, array $attachments = []): bool;
+}

--- a/src/Mailer/MailManager.php
+++ b/src/Mailer/MailManager.php
@@ -2,22 +2,24 @@
 
 namespace Asterios\Core\Mailer;
 
+use Asterios\Core\Contracts\Mailer\MailServiceInterface;
+use Asterios\Core\Exception\LoggerException;
 use Asterios\Core\Exception\MailServiceException;
 use Asterios\Core\Logger;
 
 class MailManager
 {
     private static ?MailManager $instance = null;
-    private MailService $mailService;
+    private MailServiceInterface $mailService;
     private array $templates;
 
     /**
      * @param array $templates
      * @throws MailServiceException
      */
-    private function __construct(array $templates)
+    protected function __construct(array $templates)
     {
-        $this->mailService = MailService::getInstance();
+        $this->initializeMailService();
         $this->templates = $templates;
     }
 
@@ -26,11 +28,11 @@ class MailManager
      * @return MailManager
      * @throws MailServiceException
      */
-    public static function getInstance(array $templates = []): MailManager
+    public static function getInstance(array $templates = []): self
     {
         if (self::$instance === null)
         {
-            self::$instance = new MailManager($templates);
+            self::$instance = static::create($templates);
         }
         return self::$instance;
     }
@@ -43,13 +45,10 @@ class MailManager
      * @param array $context
      * @param array $attachments
      * @return bool
+     * @throws LoggerException
      */
-    public function sendTemplate(
-        string|array $to,
-        string $templateKey,
-        array $context = [],
-        array $attachments = []
-    ): bool {
+    public function sendTemplate(string|array $to, string $templateKey, array $context = [], array $attachments = []): bool
+    {
         if (!isset($this->templates[$templateKey]))
         {
             $this->logError('MailManager: Template '.$templateKey.' not found.');
@@ -61,15 +60,19 @@ class MailManager
         $subject = $this->replacePlaceholders($tpl['subject'], $context);
         $templateFile = $tpl['template'] ?? null;
 
-        return $this->mailService->send(
-            $to,
-            $subject,
-            $templateFile,
-            $context,
-            null,
-            null,
-            $attachments
-        );
+        return $this->mailService->send($to, $subject, $templateFile, $context, null, null, $attachments);
+    }
+
+    /**
+     * @param string|array $to
+     * @param string $subject
+     * @param string $text
+     * @param array $attachments
+     * @return bool
+     */
+    public function sendText(string|array $to, string $subject, string $text, array $attachments = []): bool
+    {
+        return $this->mailService->send($to, $subject, null, [], null, $text, $attachments);
     }
 
     public function registerTemplate(string $key, string $templateFile, string $subject): void
@@ -80,6 +83,11 @@ class MailManager
         ];
     }
 
+    /**
+     * @param string $text
+     * @param array $context
+     * @return string
+     */
     private function replacePlaceholders(string $text, array $context): string
     {
         foreach ($context as $key => $value)
@@ -92,8 +100,51 @@ class MailManager
         return $text;
     }
 
+    /**
+     * @param string $msg
+     * @return void
+     * @throws LoggerException
+     */
     protected function logError(string $msg): void
     {
         Logger::forge()->error($msg);
+    }
+
+    /**
+     * @param array $templates
+     * @return static
+     * @throws MailServiceException
+     */
+    protected static function create(array $templates): static
+    {
+        return new static($templates);
+    }
+
+    /**
+     * @param MailServiceInterface $mailService
+     * @return void
+     */
+    protected function setMailService(MailServiceInterface $mailService): void
+    {
+        $this->mailService = $mailService;
+    }
+
+    /**
+     * @param array $templates
+     * @return static
+     * @throws MailServiceException
+     */
+    public static function createManager(array $templates = []): static
+    {
+        return static::create($templates);
+    }
+
+    /**
+     * @return void
+     * @throws MailServiceException
+     */
+    protected function initializeMailService(): void
+    {
+        $this->mailService = MailService::getInstance();
     }
 }

--- a/src/Mailer/MailService.php
+++ b/src/Mailer/MailService.php
@@ -3,6 +3,7 @@
 namespace Asterios\Core\Mailer;
 
 use Asterios\Core\Asterios;
+use Asterios\Core\Contracts\Mailer\MailServiceInterface;
 use Asterios\Core\Env;
 use Asterios\Core\Exception\EnvException;
 use Asterios\Core\Exception\EnvLoadException;
@@ -10,48 +11,34 @@ use Asterios\Core\Exception\MailServiceException;
 use Asterios\Core\Logger;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\Mailer\Mailer;
+use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mailer\Transport;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Twig\Environment as Twig;
+use Twig\Error\LoaderError;
 use Twig\Loader\FilesystemLoader;
 
-class MailService
+class MailService implements MailServiceInterface
 {
     private static ?MailService $instance = null;
     protected string $envFile = '.env';
     protected ?Env $env = null;
-    private Mailer $mailer;
-    private string $fromAddress;
-    private string $fromName;
+    protected ?MailerInterface $mailer = null;
+    protected string $fromAddress;
+    protected string $fromName;
     private ?Twig $twig = null;
 
     /**
      * @param string $envFile
      * @throws MailServiceException
      */
-    private function __construct(string $envFile = '.env')
+    protected function __construct(string $envFile = '.env')
     {
-        $this->envFile = Asterios::getBasePath() . DIRECTORY_SEPARATOR . $envFile;
-
-        if (null === $this->env)
-        {
-            $this->env = new Env($this->envFile);
-        }
-
-        $transport = Transport::fromDsn($this->getDsn());
-        $this->mailer = $this->getMailer($transport);
-
-        $this->fromAddress = $this->getMailFromAddress();
-        $this->fromName = $this->getMailFromName();
-        $templatesPath = $this->getMailTemplatePath();
-
-        if ($templatesPath && is_dir($templatesPath))
-        {
-            $loader = $this->getFilesystemLoader($templatesPath);
-            $this->twig = $this->getTwig($loader);
-        }
+        $this->initializeEnv($envFile);
+        $this->initializeMailer();
+        $this->initializeTwig();
     }
 
     /**
@@ -59,35 +46,21 @@ class MailService
      * @return MailService
      * @throws MailServiceException
      */
-    public static function getInstance(string $envFile = '.env'): MailService
+    public static function getInstance(string $envFile = '.env'): static
     {
         if (self::$instance === null)
         {
-            self::$instance = new MailService($envFile);
+            self::$instance = static::create($envFile);
         }
 
         return self::$instance;
     }
 
     /**
-     * @param string|array $to
-     * @param string $subject
-     * @param string|null $template
-     * @param array $context
-     * @param string|null $htmlBody
-     * @param string|null $plainText
-     * @param array $attachments
-     * @return bool
+     * @inheritDoc
      */
-    public function send(
-        string|array $to,
-        string $subject,
-        ?string $template = null,
-        array $context = [],
-        ?string $htmlBody = null,
-        ?string $plainText = null,
-        array $attachments = []
-    ): bool {
+    public function send(string|array $to, string $subject, ?string $template = null, array $context = [], ?string $htmlBody = null, ?string $plainText = null, array $attachments = []): bool
+    {
         try
         {
             $email = $this->buildEmail($to, $subject, $template, $context, $htmlBody, $plainText);
@@ -118,7 +91,7 @@ class MailService
         }
     }
 
-    private function buildEmail(
+    protected function buildEmail(
         string|array $to,
         string $subject,
         ?string $template,
@@ -126,67 +99,86 @@ class MailService
         ?string $htmlBody,
         ?string $plainText
     ): Email {
-        $recipients = (array) $to;
+        $recipients = (array)$to;
 
-        if ($template && $this->twig)
+        if ($template)
         {
-            try
+            $base = preg_replace('/(\.html|\.txt)?\.twig$/', '', $template);
+
+            $htmlTemplate = $base . '.html.twig';
+            $textTemplate = $base . '.txt.twig';
+
+            if ($this->templateExists($htmlTemplate))
             {
-                $htmlBody = $this->twig->render($template, $context);
-            }
-            catch (\Throwable $e)
-            {
-                $this->logError('Twig render error: '.$e->getMessage());
-                $htmlBody = null;
+                $htmlBody = $this->renderTemplate($htmlTemplate, $context);
             }
 
-            if (class_exists(TemplatedEmail::class))
+            if ($this->templateExists($textTemplate))
             {
-                $email = $this->getTemplatedEmail()
-                    ->from($this->getAddress($this->fromAddress, $this->fromName))
-                    ->to(...$recipients)
-                    ->subject($subject)
-                    ->html($htmlBody ?? '');
+                $plainText = $this->renderTemplate($textTemplate, $context);
             }
-            else
-            {
-                $email = $this->getEmail()
-                    ->from($this->getAddress($this->fromAddress, $this->fromName))
-                    ->to(...$recipients)
-                    ->subject($subject)
-                    ->html($htmlBody ?? '');
+
+            if (
+                $htmlBody === null &&
+                $plainText === null &&
+                $this->templateExists($template)
+            ) {
+                $htmlBody = $this->renderTemplate($template, $context);
             }
+        }
+
+        if (class_exists(TemplatedEmail::class))
+        {
+            $email = $this->getTemplatedEmail();
         }
         else
         {
+            $email = $this->getEmail();
+        }
 
-            $email = $this->getEmail()
-                ->from($this->getAddress($this->fromAddress, $this->fromName))
-                ->to(...$recipients)
-                ->subject($subject);
+        $email
+            ->from($this->getAddress($this->fromAddress, $this->fromName))
+            ->to(...$recipients)
+            ->subject($subject);
 
+        if ($htmlBody !== null)
+        {
+            $email->html($htmlBody);
+        }
 
-            if ($htmlBody)
-            {
-                $email->html($htmlBody);
-            }
-            else
-            {
-                $email->html('');
-            }
-
-
-            if ($plainText)
-            {
-                $email->text($plainText);
-            }
-            else
-            {
-                $email->text(strip_tags($htmlBody ?? ''));
-            }
+        if ($plainText !== null)
+        {
+            $email->text($plainText);
+        }
+        elseif ($htmlBody !== null)
+        {
+            $email->text(strip_tags($htmlBody));
         }
 
         return $email;
+    }
+
+    /**
+     * @param string $template
+     * @param array $context
+     * @return string|null
+     */
+    protected function renderTemplate(string $template, array $context): ?string
+    {
+        if (!$this->twig)
+        {
+            return null;
+        }
+
+        try
+        {
+            return $this->twig->render($template, $context);
+        }
+        catch (\Throwable $e)
+        {
+            $this->logError('Twig render error: ' . $e->getMessage());
+            return null;
+        }
     }
 
     /**
@@ -273,9 +265,9 @@ class MailService
 
     /**
      * @param TransportInterface $transport
-     * @return Mailer
+     * @return MailerInterface
      */
-    protected function getMailer(TransportInterface $transport): Mailer
+    protected function getMailer(TransportInterface $transport): MailerInterface
     {
         return new Mailer($transport);
     }
@@ -318,5 +310,82 @@ class MailService
     protected function getProtectedPath(): string
     {
         return Asterios::getBasePath();
+    }
+
+    protected function templateExists(string $template): bool
+    {
+        if (!$this->twig)
+        {
+            return false;
+        }
+
+        try
+        {
+            $this->twig->getLoader()->getSourceContext($template);
+            return true;
+        }
+        catch (LoaderError)
+        {
+            return false;
+        }
+    }
+
+    /**
+     * @return void
+     * @throws MailServiceException
+     */
+    protected function initializeMailer(): void
+    {
+        $transport = Transport::fromDsn($this->getDsn());
+        $this->mailer = $this->getMailer($transport);
+
+        $this->fromAddress = $this->getMailFromAddress();
+        $this->fromName = $this->getMailFromName();
+    }
+
+    /**
+     * @return void
+     * @throws MailServiceException
+     */
+    protected function initializeTwig(): void
+    {
+        $templatesPath = $this->getMailTemplatePath();
+
+        if ($templatesPath && is_dir($templatesPath))
+        {
+            $loader = $this->getFilesystemLoader($templatesPath);
+            $this->twig = $this->getTwig($loader);
+        }
+    }
+
+    /**
+     * @throws MailServiceException
+     */
+    protected static function create(string $envFile = '.env'): static
+    {
+        return new static($envFile);
+    }
+
+    /**
+     * @param string $envFile
+     * @return void
+     */
+    protected function initializeEnv(string $envFile): void
+    {
+        $this->envFile = Asterios::getBasePath() . DIRECTORY_SEPARATOR . $envFile;
+
+        if (null === $this->env)
+        {
+            $this->env = new Env($this->envFile);
+        }
+    }
+
+    /**
+     * @param MailerInterface $mailer
+     * @return void
+     */
+    protected function setMailer(MailerInterface $mailer): void
+    {
+        $this->mailer = $mailer;
     }
 }

--- a/tests/Mailer/MailManagerTest.php
+++ b/tests/Mailer/MailManagerTest.php
@@ -1,0 +1,248 @@
+<?php declare(strict_types=1);
+
+namespace Asterios\Test\Mailer;
+
+use Asterios\Core\Contracts\Mailer\MailServiceInterface;
+use Asterios\Core\Exception\LoggerException;
+use Asterios\Core\Exception\MailServiceException;
+use Asterios\Core\Mailer\MailManager;
+use PHPUnit\Framework\TestCase;
+
+final class MailManagerTest extends TestCase
+{
+    private TestMailManagerDouble $manager;
+    private TestMailServiceDouble $mailService;
+
+    /**
+     * @throws MailServiceException
+     */
+    protected function setUp(): void
+    {
+        $this->manager = TestMailManagerDouble::createManager();
+
+        $this->mailService = new TestMailServiceDouble();
+
+        $this->manager->injectMailService($this->mailService);
+    }
+
+    public function testSendText(): void
+    {
+        $this->mailService->returnValue = true;
+
+        self::assertTrue(
+            $this->manager->sendText(
+                'john@example.com',
+                'Subject',
+                'Hello World'
+            )
+        );
+
+        self::assertSame('john@example.com', $this->mailService->lastCall['to']);
+        self::assertSame('Subject', $this->mailService->lastCall['subject']);
+        self::assertNull($this->mailService->lastCall['template']);
+        self::assertSame([], $this->mailService->lastCall['context']);
+        self::assertNull($this->mailService->lastCall['html']);
+        self::assertSame('Hello World', $this->mailService->lastCall['text']);
+        self::assertSame([], $this->mailService->lastCall['attachments']);
+    }
+
+    public function testSendTextReturnsFalse(): void
+    {
+        $this->mailService->returnValue = false;
+
+        self::assertFalse(
+            $this->manager->sendText(
+                'john@example.com',
+                'Subject',
+                'Hello World'
+            )
+        );
+    }
+
+    /**
+     * @return void
+     * @throws LoggerException
+     * @throws MailServiceException
+     */
+    public function testSendTemplate(): void
+    {
+        $this->manager = TestMailManagerDouble::createManager([
+            'welcome' => [
+                'template' => 'welcome.twig',
+                'subject' => 'Welcome'
+            ]
+        ]);
+
+        $this->manager->injectMailService($this->mailService);
+
+        $this->mailService->returnValue = true;
+
+        self::assertTrue(
+            $this->manager->sendTemplate(
+                'john@example.com',
+                'welcome'
+            )
+        );
+
+        self::assertSame('john@example.com', $this->mailService->lastCall['to']);
+        self::assertSame('Welcome', $this->mailService->lastCall['subject']);
+        self::assertSame('welcome.twig', $this->mailService->lastCall['template']);
+        self::assertSame([], $this->mailService->lastCall['context']);
+        self::assertNull($this->mailService->lastCall['html']);
+        self::assertNull($this->mailService->lastCall['text']);
+    }
+
+    /**
+     * @return void
+     * @throws MailServiceException
+     * @throws LoggerException
+     */
+    public function testSendTemplateReplacesPlaceholders(): void
+    {
+        $this->manager = TestMailManagerDouble::createManager([
+            'welcome' => [
+                'template' => 'welcome.twig',
+                'subject' => 'Hello {{name}}'
+            ]
+        ]);
+
+        $this->manager->injectMailService($this->mailService);
+
+        self::assertTrue(
+            $this->manager->sendTemplate(
+                'john@example.com',
+                'welcome',
+                [
+                    'name' => 'John'
+                ]
+            )
+        );
+
+        self::assertSame(
+            'Hello John',
+            $this->mailService->lastCall['subject']
+        );
+
+        self::assertSame(
+            ['name' => 'John'],
+            $this->mailService->lastCall['context']
+        );
+    }
+
+    /**
+     * @return void
+     * @throws LoggerException
+     */
+    public function testSendTemplateReturnsFalseIfTemplateMissing(): void
+    {
+        self::assertFalse(
+            $this->manager->sendTemplate(
+                'john@example.com',
+                'unknown'
+            )
+        );
+    }
+
+    /**
+     * @return void
+     * @throws LoggerException
+     */
+    public function testRegisterTemplate(): void
+    {
+        $this->manager->registerTemplate(
+            'welcome',
+            'welcome.twig',
+            'Welcome {{name}}'
+        );
+
+        self::assertTrue(
+            $this->manager->sendTemplate(
+                'john@example.com',
+                'welcome',
+                [
+                    'name' => 'John'
+                ]
+            )
+        );
+
+        self::assertSame(
+            'Welcome John',
+            $this->mailService->lastCall['subject']
+        );
+
+        self::assertSame(
+            'welcome.twig',
+            $this->mailService->lastCall['template']
+        );
+    }
+
+    /**
+     * @throws MailServiceException
+     */
+    public function testGetInstanceReturnsMailManager(): void
+    {
+        $manager = TestMailManagerDouble::getInstance();
+
+        $this->assertInstanceOf(
+            TestMailManagerDouble::class,
+            $manager
+        );
+    }
+
+    /**
+     * @throws MailServiceException
+     */
+    public function testGetInstanceReturnsSameInstance(): void
+    {
+        $first = TestMailManagerDouble::getInstance();
+        $second = TestMailManagerDouble::getInstance();
+
+        $this->assertSame($first, $second);
+    }
+}
+
+final class TestMailManagerDouble extends MailManager
+{
+    protected function initializeMailService(): void
+    {
+    }
+
+    public function injectMailService(
+        MailServiceInterface $mailService
+    ): void {
+        $this->setMailService($mailService);
+    }
+
+    protected function logError(string $msg): void
+    {
+    }
+}
+
+final class TestMailService implements MailServiceInterface
+{
+    public bool $returnValue = true;
+
+    public array $lastCall = [];
+
+    public function send(
+        string|array $to,
+        string $subject,
+        ?string $template = null,
+        array $context = [],
+        ?string $htmlBody = null,
+        ?string $plainText = null,
+        array $attachments = []
+    ): bool {
+        $this->lastCall = [
+            'to'          => $to,
+            'subject'     => $subject,
+            'template'    => $template,
+            'context'     => $context,
+            'html'        => $htmlBody,
+            'text'        => $plainText,
+            'attachments' => $attachments,
+        ];
+
+        return $this->returnValue;
+    }
+}

--- a/tests/Mailer/MailServiceTest.php
+++ b/tests/Mailer/MailServiceTest.php
@@ -1,0 +1,450 @@
+<?php declare(strict_types=1);
+
+namespace Asterios\Test\Mailer;
+
+use Asterios\Core\Exception\MailServiceException;
+use Asterios\Core\Mailer\MailService;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Email;
+
+final class MailServiceTest extends TestCase
+{
+    private TestMailServiceDouble $mailService;
+
+    protected function setUp(): void
+    {
+        $this->mailService = new TestMailServiceDouble();
+    }
+
+    public function testBuildEmailWithHtmlBody(): void
+    {
+        $email = $this->mailService->build(
+            'john@example.com',
+            'Test Subject',
+            null,
+            [],
+            '<h1>Hello</h1><p>World</p>'
+        );
+
+        self::assertInstanceOf(Email::class, $email);
+
+        self::assertSame('Test Subject', $email->getSubject());
+
+        self::assertCount(1, $email->getTo());
+        self::assertSame('john@example.com', $email->getTo()[0]->getAddress());
+
+        self::assertSame('noreply@example.com', $email->getFrom()[0]->getAddress());
+        self::assertSame('Asterios Test', $email->getFrom()[0]->getName());
+
+        self::assertSame('<h1>Hello</h1><p>World</p>', $email->getHtmlBody());
+        self::assertSame('HelloWorld', trim($email->getTextBody()));
+    }
+
+    public function testBuildEmailWithPlainTextOnly(): void
+    {
+        $email = $this->mailService->build(
+            'john@example.com',
+            'Test Subject',
+            null,
+            [],
+            null,
+            'Hello World'
+        );
+
+        self::assertNull($email->getHtmlBody());
+        self::assertSame('Hello World', $email->getTextBody());
+    }
+
+    public function testBuildEmailUsesExplicitPlainTextInsteadOfStripTags(): void
+    {
+        $email = $this->mailService->build(
+            'john@example.com',
+            'Test Subject',
+            null,
+            [],
+            '<h1>Hello</h1>',
+            'Custom Text'
+        );
+
+        self::assertSame('<h1>Hello</h1>', $email->getHtmlBody());
+        self::assertSame('Custom Text', $email->getTextBody());
+    }
+
+    public function testBuildEmailWithMultipleRecipients(): void
+    {
+        $email = $this->mailService->build(
+            [
+                'john@example.com',
+                'jane@example.com',
+            ],
+            'Test Subject'
+        );
+
+        self::assertCount(2, $email->getTo());
+        self::assertSame('john@example.com', $email->getTo()[0]->getAddress());
+        self::assertSame('jane@example.com', $email->getTo()[1]->getAddress());
+    }
+
+    public function testBuildEmailUsesTwigTemplate(): void
+    {
+        $this->mailService->addTemplate(
+            'mail.twig',
+            '<h1>Hello Twig</h1>'
+        );
+
+        $email = $this->mailService->build(
+            'john@example.com',
+            'Test',
+            'mail.twig'
+        );
+
+        self::assertSame(
+            '<h1>Hello Twig</h1>',
+            $email->getHtmlBody()
+        );
+
+        self::assertSame(
+            'Hello Twig',
+            trim($email->getTextBody())
+        );
+    }
+
+    public function testBuildEmailUsesHtmlAndTextTemplates(): void
+    {
+        $this->mailService->addTemplate(
+            'mail.html.twig',
+            '<h1>Hello HTML</h1>'
+        );
+
+        $this->mailService->addTemplate(
+            'mail.txt.twig',
+            'Hello TEXT'
+        );
+
+        $email = $this->mailService->build(
+            'john@example.com',
+            'Test',
+            'mail.twig'
+        );
+
+        self::assertSame(
+            '<h1>Hello HTML</h1>',
+            $email->getHtmlBody()
+        );
+
+        self::assertSame(
+            'Hello TEXT',
+            $email->getTextBody()
+        );
+    }
+
+    public function testBuildEmailUsesHtmlTemplateOnly(): void
+    {
+        $this->mailService->addTemplate(
+            'mail.html.twig',
+            '<h1>Hello HTML</h1>'
+        );
+
+        $email = $this->mailService->build(
+            'john@example.com',
+            'Test',
+            'mail.twig'
+        );
+
+        self::assertSame(
+            '<h1>Hello HTML</h1>',
+            $email->getHtmlBody()
+        );
+
+        self::assertSame(
+            'Hello HTML',
+            trim($email->getTextBody())
+        );
+    }
+
+    public function testBuildEmailUsesTextTemplateOnly(): void
+    {
+        $this->mailService->addTemplate(
+            'mail.txt.twig',
+            'Hello TEXT'
+        );
+
+        $email = $this->mailService->build(
+            'john@example.com',
+            'Test',
+            'mail.twig'
+        );
+
+        self::assertNull($email->getHtmlBody());
+
+        self::assertSame(
+            'Hello TEXT',
+            $email->getTextBody()
+        );
+    }
+
+    public function testSendReturnsTrue(): void
+    {
+        $mailer = $this->createMock(MailerInterface::class);
+
+        $mailer
+            ->expects($this->once())
+            ->method('send');
+
+        $this->mailService->injectMailer($mailer);
+
+        self::assertTrue(
+            $this->mailService->send(
+                'john@example.com',
+                'Test',
+                null,
+                [],
+                '<h1>Hello</h1>'
+            )
+        );
+    }
+
+    public function testSendReturnsFalseOnMailerException(): void
+    {
+        $mailer = $this->createMock(MailerInterface::class);
+
+        $mailer
+            ->expects($this->once())
+            ->method('send')
+            ->willThrowException(new \RuntimeException('Test exception'));
+
+        $this->mailService->injectMailer($mailer);
+
+        self::assertFalse(
+            $this->mailService->send(
+                'john@example.com',
+                'Test',
+                null,
+                [],
+                '<h1>Hello</h1>'
+            )
+        );
+    }
+
+    public function testSendPassesEmailToMailer(): void
+    {
+        $mailer = $this->createMock(MailerInterface::class);
+
+        $mailer
+            ->expects($this->once())
+            ->method('send')
+            ->with(self::callback(static function (Email $email) {
+                self::assertSame('Test', $email->getSubject());
+                self::assertSame(
+                    '<h1>Hello</h1>',
+                    $email->getHtmlBody()
+                );
+
+                return true;
+            }));
+
+        $this->mailService->injectMailer($mailer);
+
+        self::assertTrue(
+            $this->mailService->send(
+                'john@example.com',
+                'Test',
+                null,
+                [],
+                '<h1>Hello</h1>'
+            )
+        );
+    }
+
+    public function testSendAttachesFile(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'mail');
+        file_put_contents($file, 'Hello Attachment');
+
+        try
+        {
+            $mailer = $this->createMock(MailerInterface::class);
+
+            $mailer
+                ->expects($this->once())
+                ->method('send')
+                ->with(self::callback(static function (Email $email) {
+                    self::assertCount(1, $email->getAttachments());
+
+                    return true;
+                }));
+
+            $this->mailService->injectMailer($mailer);
+
+            self::assertTrue(
+                $this->mailService->send(
+                    'john@example.com',
+                    'Test',
+                    null,
+                    [],
+                    '<h1>Hello</h1>',
+                    null,
+                    [$file]
+                )
+            );
+        }
+        finally
+        {
+            @unlink($file);
+        }
+    }
+
+    public function testSendAttachesBinaryAttachment(): void
+    {
+        $mailer = $this->createMock(MailerInterface::class);
+
+        $mailer
+            ->expects($this->once())
+            ->method('send')
+            ->with(self::callback(static function (Email $email) {
+                self::assertCount(1, $email->getAttachments());
+
+                return true;
+            }));
+
+        $this->mailService->injectMailer($mailer);
+
+        self::assertTrue(
+            $this->mailService->send(
+                'john@example.com',
+                'Test',
+                null,
+                [],
+                '<h1>Hello</h1>',
+                null,
+                [[
+                    'content'  => 'Hello World',
+                    'filename' => 'hello.txt',
+                    'mime'     => 'text/plain',
+                ]]
+            )
+        );
+    }
+
+    public function testSendIgnoresMissingAttachment(): void
+    {
+        $mailer = $this->createMock(MailerInterface::class);
+
+        $mailer
+            ->expects($this->once())
+            ->method('send')
+            ->with($this->callback(static function (Email $email) {
+                self::assertCount(0, $email->getAttachments());
+
+                return true;
+            }));
+
+        $this->mailService->injectMailer($mailer);
+
+        $this->assertTrue(
+            $this->mailService->send(
+                'john@example.com',
+                'Test',
+                null,
+                [],
+                '<h1>Hello</h1>',
+                null,
+                ['/does/not/exist.txt']
+            )
+        );
+    }
+
+    /**
+     * @return void
+     * @throws MailServiceException
+     */
+    public function testGetInstanceReturnsMailService(): void
+    {
+        $service = TestMailServiceDouble::getInstance();
+
+        $this->assertInstanceOf(TestMailServiceDouble::class, $service);
+    }
+
+    /**
+     * @return void
+     * @throws MailServiceException
+     */
+    public function testGetInstanceReturnsSameInstance(): void
+    {
+        $first = TestMailServiceDouble::getInstance();
+        $second = TestMailServiceDouble::getInstance();
+
+        $this->assertSame($first, $second);
+    }
+}
+
+final class TestMailServiceDouble extends MailService
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    protected function initializeEnv(string $envFile): void
+    {
+        // keine .env laden
+    }
+
+    protected function initializeMailer(): void
+    {
+        $this->fromAddress = 'noreply@example.com';
+        $this->fromName = 'Asterios Test';
+
+    }
+
+    protected function initializeTwig(): void
+    {
+        // kein Twig
+    }
+
+    public function build(
+        string|array $to,
+        string $subject,
+        ?string $template = null,
+        array $context = [],
+        ?string $htmlBody = null,
+        ?string $plainText = null
+    ): Email {
+        return $this->buildEmail(
+            $to,
+            $subject,
+            $template,
+            $context,
+            $htmlBody,
+            $plainText
+        );
+    }
+
+    private array $templates = [];
+    private array $renderedTemplates = [];
+
+    public function addTemplate(string $name, string $content): void
+    {
+        $this->templates[$name] = $content;
+    }
+
+    protected function templateExists(string $template): bool
+    {
+        return isset($this->templates[$template]);
+    }
+
+    protected function renderTemplate(string $template, array $context): ?string
+    {
+        return $this->templates[$template] ?? null;
+    }
+
+    public function injectMailer(MailerInterface $mailer): void
+    {
+        $this->setMailer($mailer);
+    }
+
+    protected function logError(string $msg): void
+    {
+    }
+}


### PR DESCRIPTION
This PR extends the mail component with support for plain text emails and proper multipart emails (HTML + plain text), while maintaining full backward compatibility with existing HTML email templates.

Additionally, the mail component has been refactored to improve testability and is now covered by comprehensive unit tests.

<h2 data-section-id="1d7mrtu" data-start="469" data-end="480" class="PDq2pG_selectionAnchorContainer">Features<span aria-hidden="true" class="PDq2pG_selectionAnchor"></span></h2>
<ul data-start="482" data-end="831">
<li data-section-id="1ohxe58" data-start="482" data-end="557">
Added support for sending plain text emails via <code data-start="532" data-end="557">MailManager::sendText()</code>
</li>
<li data-section-id="12cimff" data-start="558" data-end="618">
Added support for plain text Twig templates (<code data-start="605" data-end="617">*.txt.twig</code>)
</li>
<li data-section-id="icq04i" data-start="619" data-end="690">
Added support for multipart emails using both HTML and text templates
</li>
<li data-section-id="1rod2em" data-start="691" data-end="773">
Automatic plain text fallback (<code data-start="724" data-end="738">strip_tags()</code>) when only an HTML template exists
</li>
<li data-section-id="h3z942" data-start="774" data-end="831">
Subject placeholder replacement remains fully supported
</li>
</ul>
<h2 data-section-id="1aef5p7" data-start="833" data-end="855">Template Resolution</h2>
<div class="TyagGW_tableContainer"><div tabindex="-1" class="group TyagGW_tableWrapper flex flex-col-reverse w-fit">
Available templates | Result
-- | --
template.html.twig + template.txt.twig | Multipart email (HTML + plain text)
template.html.twig only | HTML email with automatically generated plain text part
template.txt.twig only | Plain text email

</div></div>
<h2 data-section-id="1jxe7mn" data-start="1145" data-end="1159">Refactoring</h2>
<p data-start="1161" data-end="1204">To improve maintainability and testability:</p>
<ul data-start="1206" data-end="1455">
<li data-section-id="1xc7ajo" data-start="1206" data-end="1241">
Introduced <code data-start="1219" data-end="1241">MailServiceInterface</code>
</li>
<li data-section-id="z4sibv" data-start="1242" data-end="1299">
Decoupled <code data-start="1254" data-end="1267">MailManager</code> from the concrete <code data-start="1286" data-end="1299">MailService</code>
</li>
<li data-section-id="1rwen86" data-start="1300" data-end="1364">
Extracted internal initialization logic into dedicated methods
</li>
<li data-section-id="6a4cg" data-start="1365" data-end="1408">
Added factory methods to simplify testing
</li>
<li data-section-id="15zoaza" data-start="1409" data-end="1455">
Improved dependency injection for unit tests
</li>
</ul>
<p data-start="1457" data-end="1526">These changes are internal only and do <strong data-start="1496" data-end="1503">not</strong> affect the public API.</p>
<h2 data-section-id="xlct5s" data-start="1528" data-end="1536">Tests</h2>
<p data-start="1538" data-end="1620">Added comprehensive unit tests for both <code data-start="1578" data-end="1591">MailService</code> and <code data-start="1596" data-end="1609">MailManager</code>, covering:</p>
<ul data-start="1622" data-end="1861">
<li data-section-id="185tazj" data-start="1622" data-end="1645">
HTML email generation
</li>
<li data-section-id="te1a05" data-start="1646" data-end="1675">
Plain text email generation
</li>
<li data-section-id="1v6dfss" data-start="1676" data-end="1704">
Multipart email generation
</li>
<li data-section-id="yo7nva" data-start="1705" data-end="1726">
Template resolution
</li>
<li data-section-id="1gfwl3d" data-start="1727" data-end="1760">
Subject placeholder replacement
</li>
<li data-section-id="145xwf6" data-start="1761" data-end="1774">
Attachments
</li>
<li data-section-id="1dje7jz" data-start="1775" data-end="1791">
Error handling
</li>
<li data-section-id="1wrko7f" data-start="1792" data-end="1812">
Singleton behavior
</li>
<li data-section-id="dwnct5" data-start="1813" data-end="1861">
Delegation from <code data-start="1831" data-end="1844">MailManager</code> to <code data-start="1848" data-end="1861">MailService</code>
</li>
</ul>
<h2 data-section-id="15fl3sw" data-start="1863" data-end="1888">Backward Compatibility</h2>
<p data-start="1890" data-end="1931">This change is fully backward compatible.</p>
<p data-start="1933" data-end="2142" data-is-last-node="" data-is-only-node="">Existing HTML email templates continue to work without modification. Projects can gradually introduce <code data-start="2035" data-end="2047">*.txt.twig</code> templates to provide native plain text support without changing any existing application code.</p>
<!--- START AUTOGENERATED NOTES --->
# Contents ([#174](https://github.com/asteriosframework/core/pull/174))

### Other
- introduce `MailServiceInterface` and enhance `MailService` and `MailManager` functionality

<!--- END AUTOGENERATED NOTES --->